### PR TITLE
'...' range patterns are deprecated, fix it

### DIFF
--- a/src/n0008_string_to_integer_atoi.rs
+++ b/src/n0008_string_to_integer_atoi.rs
@@ -74,7 +74,7 @@ impl Solution {
             if !num_matched {
                 match ch {
                     ' ' => {},
-                    '0'...'9' => {
+                    '0'..='9' => {
                         num_matched = true;
                         result = result * 10 + ch.to_digit(10).unwrap() as i64;
                     },
@@ -84,7 +84,7 @@ impl Solution {
                 }
             } else {
                 match ch {
-                    '0'...'9' => {
+                    '0'..='9' => {
                         result = result * 10 + ch.to_digit(10).unwrap() as i64;
                         if result > i32_max { break }
                     },

--- a/src/n0224_basic_calculator.rs
+++ b/src/n0224_basic_calculator.rs
@@ -52,7 +52,7 @@ impl Solution {
         let mut in_num = false;
         for ch in s.chars() {
             match ch {
-                '0'...'9' => {
+                '0'..='9' => {
                     in_num = true;
                     num = 10 * num + (ch as u8 - '0' as u8) as i64;
                 }

--- a/src/n0227_basic_calculator_ii.rs
+++ b/src/n0227_basic_calculator_ii.rs
@@ -47,7 +47,7 @@ impl Solution {
         let mut multiple = true;
         for ch in s.chars() {
             match ch {
-                '0'...'9' => { curr = 10 * curr + (ch as u8 - '0' as u8) as i64; },
+                '0'..='9' => { curr = 10 * curr + (ch as u8 - '0' as u8) as i64; },
                 '+' | '-' => {
                     if has_prev {
                         if multiple {


### PR DESCRIPTION
Compile the previous program results in serveral following warnings:

> warning: `...` range patterns are deprecated
>   --> src/n0008_string_to_integer_atoi.rs:77:24
>    |
> 77 |                     '0'...'9' => {
>    |                        ^^^ help: use `..=` for an inclusive range
>    |
>    = note: `#[warn(ellipsis_inclusive_range_patterns)]` on by default

See this [link](https://github.com/rust-lang/book/pull/2072) for more details