### PR TITLE
fix 26

### DIFF
--- a/src/solution/s0026_remove_duplicates_from_sorted_array.rs
+++ b/src/solution/s0026_remove_duplicates_from_sorted_array.rs
@@ -63,6 +63,7 @@ impl Solution {
                 nums[slow] = nums[fast];
             }
         }
+        nums.truncate(slow + 1);
         (slow + 1) as i32
     }
 }


### PR DESCRIPTION
```
---- solution::s0026_remove_duplicates_from_sorted_array::tests::test_26 stdout ----
thread 'solution::s0026_remove_duplicates_from_sorted_array::tests::test_26' panicked at 'assertion failed: `(left == right)`
  left: `[1, 3, 1, 1, 3]`,
 right: `[1, 3]`', src/solution/s0026_remove_duplicates_from_sorted_array.rs:81:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Test failed because the vector wasn't truncated to the new size. Fixed this.